### PR TITLE
Limit purchases until funds are available

### DIFF
--- a/src/elm/Data/Currency.elm
+++ b/src/elm/Data/Currency.elm
@@ -2,6 +2,7 @@ module Data.Currency
     exposing
         ( Currency(..)
         , add
+        , gte
         , map
         , multiply
         , subtract
@@ -17,6 +18,11 @@ type Currency
 map : (Float -> Float) -> Currency -> Currency
 map f (Currency c) =
     Currency <| f c
+
+
+gte : Currency -> Currency -> Bool
+gte (Currency c1) (Currency c2) =
+    c1 >= c2
 
 
 map2 : (Float -> Float -> Float) -> Currency -> Currency -> Currency

--- a/src/elm/Data/Resource.elm
+++ b/src/elm/Data/Resource.elm
@@ -6,6 +6,7 @@ module Data.Resource
         , build
         , currentPrice
         , purchase
+        , replace
         , totalIncomeRate
         , transactionCost
         )
@@ -141,3 +142,11 @@ increasePurchased (Count count) resource =
 totalIncomeRate : List Resource -> IncomeRate
 totalIncomeRate =
     IncomeRate.sum << List.map incomeRatePerSecond
+
+
+replace : Resource -> Resource -> Resource -> Resource
+replace oldResource newResource r =
+    if r == oldResource then
+        newResource
+    else
+        r

--- a/src/elm/Model.elm
+++ b/src/elm/Model.elm
@@ -3,6 +3,7 @@ module Model
         ( Model
         , Msg(..)
         , initial
+        , purchaseResource
         )
 
 import Data.Currency as Currency exposing (Currency(..))
@@ -39,3 +40,32 @@ initial =
         , Resource.build "Bicycle" 47 1.07 (Currency 12000)
         ]
     }
+
+
+purchaseResource : Int -> Resource.Resource -> Model -> Model
+purchaseResource count resource model =
+    let
+        transaction =
+            Resource.purchase count resource
+
+        newResource =
+            Resource.applyTransaction transaction
+
+        newResources =
+            List.map (Resource.replace resource newResource) model.resources
+
+        finalCost =
+            Resource.transactionCost transaction
+    in
+    if model |> canPayFor finalCost then
+        { model
+            | resources = newResources
+            , availableFunds = Currency.subtract finalCost model.availableFunds
+        }
+    else
+        model
+
+
+canPayFor : Currency -> Model -> Bool
+canPayFor cost { availableFunds } =
+    Currency.gte availableFunds cost

--- a/src/elm/Update.elm
+++ b/src/elm/Update.elm
@@ -50,25 +50,4 @@ update msg model =
                 ! []
 
         PurchaseResource resource ->
-            let
-                transaction =
-                    Resource.purchase 1 resource
-
-                newResource =
-                    Resource.applyTransaction transaction
-
-                newResources =
-                    List.map
-                        (\r ->
-                            if r == resource then
-                                newResource
-                            else
-                                r
-                        )
-                        model.resources
-            in
-            { model
-                | resources = newResources
-                , availableFunds = Currency.subtract (Resource.transactionCost transaction) model.availableFunds
-            }
-                ! []
+            Model.purchaseResource 1 resource model ! []

--- a/tests/ModelTest.elm
+++ b/tests/ModelTest.elm
@@ -1,0 +1,63 @@
+module ModelTest exposing (..)
+
+import Data.Currency as Currency
+import Data.Resource as Resource
+import Expect
+import Model exposing (Model)
+import Test exposing (..)
+
+
+constantCostResource : Resource.Resource
+constantCostResource =
+    Resource.build "Constant cost resource" 1 1 (Currency.Currency 5)
+
+
+doubleCostResource : Resource.Resource
+doubleCostResource =
+    Resource.build "Double cost resource" 1 2 (Currency.Currency 5)
+
+
+initialModel : Model
+initialModel =
+    let
+        initial =
+            Model.initial
+    in
+    { initial | resources = [ constantCostResource, doubleCostResource ] }
+
+
+initialModelWithAvailableFunds : Currency.Currency -> Model
+initialModelWithAvailableFunds funds =
+    let
+        model =
+            initialModel
+    in
+    { model | availableFunds = funds }
+
+
+suite : Test
+suite =
+    describe "Model"
+        [ describe "purchaseResource"
+            [ test "disallows purchasing without enough funds" <|
+                \_ ->
+                    Expect.equal
+                        (Model.purchaseResource 1 constantCostResource initialModel)
+                        initialModel
+            , test "allows purchasing with enough funds" <|
+                \_ ->
+                    Expect.equal
+                        (Model.purchaseResource 1 constantCostResource (initialModelWithAvailableFunds <| Currency.Currency 5)).availableFunds
+                        Currency.zero
+            , test "allows purchasing multiple with enough funds" <|
+                \_ ->
+                    Expect.equal
+                        (Model.purchaseResource 4 constantCostResource (initialModelWithAvailableFunds <| Currency.Currency 250)).availableFunds
+                        (Currency.Currency 230)
+            , test "maintains updated costs if the resource has a multiplier" <|
+                \_ ->
+                    Expect.equal
+                        (Model.purchaseResource 4 doubleCostResource (initialModelWithAvailableFunds <| Currency.Currency 250)).availableFunds
+                        (Currency.Currency 175)
+            ]
+        ]


### PR DESCRIPTION
What?
=====

This introduces a check when purchasing a resource to ensure funds are
avaiable prior to completing the transaction.