### PR TITLE
Shift wallet and resources to inventory

### DIFF
--- a/src/elm/Data/IncomeRate.elm
+++ b/src/elm/Data/IncomeRate.elm
@@ -2,10 +2,10 @@ module Data.IncomeRate
     exposing
         ( IncomeRate(..)
         , add
-        , addToCurrency
         , build
         , multiply
         , sum
+        , toCurrency
         , zero
         )
 
@@ -26,14 +26,14 @@ zero =
     IncomeRate Currency.zero
 
 
+toCurrency : IncomeRate -> Currency
+toCurrency (IncomeRate rate) =
+    rate
+
+
 add : IncomeRate -> IncomeRate -> IncomeRate
 add (IncomeRate i1) (IncomeRate i2) =
     IncomeRate <| Currency.add i1 i2
-
-
-addToCurrency : IncomeRate -> Currency -> Currency
-addToCurrency (IncomeRate rate) price =
-    Currency.add rate price
 
 
 multiply : IncomeRate -> Float -> IncomeRate

--- a/src/elm/Data/Inventory.elm
+++ b/src/elm/Data/Inventory.elm
@@ -1,0 +1,123 @@
+module Data.Inventory
+    exposing
+        ( Inventory
+        , accrueValue
+        , availableFunds
+        , generateCurrency
+        , initial
+        , purchaseResource
+        , replaceResources
+        , resources
+        , setAvailableFunds
+        )
+
+import Data.Currency as Currency
+import Data.IncomeRate as IncomeRate
+import Data.Resource as Resource
+
+
+type Wallet
+    = Wallet Currency.Currency
+
+
+type Inventory
+    = Inventory Wallet (List Resource.Resource)
+
+
+replaceResources : List Resource.Resource -> Inventory -> Inventory
+replaceResources newResources (Inventory wallet _) =
+    Inventory wallet newResources
+
+
+setAvailableFunds : Currency.Currency -> Inventory -> Inventory
+setAvailableFunds newFunds (Inventory _ resources) =
+    Inventory (Wallet newFunds) resources
+
+
+emptyWallet : Wallet
+emptyWallet =
+    Wallet Currency.zero
+
+
+initial : Inventory
+initial =
+    Inventory emptyWallet initialResources
+
+
+generateCurrency : Inventory -> Inventory
+generateCurrency (Inventory (Wallet funds) resources) =
+    let
+        newWallet =
+            Wallet <| Currency.add (Currency.Currency 1) funds
+    in
+    Inventory newWallet resources
+
+
+accrueValue : Float -> Inventory -> Inventory
+accrueValue frequency (Inventory (Wallet funds) resources) =
+    let
+        totalIncomeRate =
+            Resource.totalIncomeRate resources
+
+        accruedValueTotal =
+            IncomeRate.toCurrency <| IncomeRate.multiply totalIncomeRate frequency
+
+        newWallet =
+            Wallet <| Currency.add accruedValueTotal funds
+    in
+    Inventory newWallet resources
+
+
+availableFunds : Inventory -> Currency.Currency
+availableFunds (Inventory (Wallet funds) _) =
+    funds
+
+
+resources : Inventory -> List Resource.Resource
+resources (Inventory _ list) =
+    list
+
+
+purchaseResource : Int -> Resource.Resource -> Inventory -> Inventory
+purchaseResource count resource (Inventory wallet resources) =
+    let
+        transaction =
+            Resource.purchase count resource
+
+        newResource =
+            Resource.applyTransaction transaction
+
+        newResources =
+            List.map (Resource.replace resource newResource) resources
+
+        finalCost =
+            Resource.transactionCost transaction
+    in
+    if wallet |> canPayFor finalCost then
+        Inventory (deductFromWallet finalCost wallet) newResources
+    else
+        Inventory wallet resources
+
+
+canPayFor : Currency.Currency -> Wallet -> Bool
+canPayFor cost wallet =
+    Currency.gte (walletValue wallet) cost
+
+
+walletValue : Wallet -> Currency.Currency
+walletValue (Wallet value) =
+    value
+
+
+initialResources : List Resource.Resource
+initialResources =
+    [ Resource.build "Cursor" 0.1 1.07 (Currency.Currency 15)
+    , Resource.build "Backpack" 1 1.07 (Currency.Currency 100)
+    , Resource.build "Skateboard" 8 1.07 (Currency.Currency 1100)
+    , Resource.build "Bicycle" 47 1.07 (Currency.Currency 12000)
+    ]
+
+
+deductFromWallet : Currency.Currency -> Wallet -> Wallet
+deductFromWallet amount (Wallet funds) =
+    Wallet <| Currency.subtract amount funds

--- a/src/elm/Model.elm
+++ b/src/elm/Model.elm
@@ -3,18 +3,16 @@ module Model
         ( Model
         , Msg(..)
         , initial
-        , purchaseResource
         )
 
-import Data.Currency as Currency exposing (Currency(..))
 import Data.Expirable exposing (Expirable, SecondsRemaining(..), expiresIn)
+import Data.Inventory as Inventory
 import Data.Resource as Resource
 
 
 type alias Model =
     { toastMessages : List (Expirable String)
-    , availableFunds : Currency
-    , resources : List Resource.Resource
+    , inventory : Inventory.Inventory
     }
 
 
@@ -32,40 +30,5 @@ initial =
         [ expiresIn (SecondsRemaining 5) "Hi there"
         , expiresIn (SecondsRemaining 30) "This goes longer"
         ]
-    , availableFunds = Currency.zero
-    , resources =
-        [ Resource.build "Cursor" 0.1 1.07 (Currency 15)
-        , Resource.build "Backpack" 1 1.07 (Currency 100)
-        , Resource.build "Skateboard" 8 1.07 (Currency 1100)
-        , Resource.build "Bicycle" 47 1.07 (Currency 12000)
-        ]
+    , inventory = Inventory.initial
     }
-
-
-purchaseResource : Int -> Resource.Resource -> Model -> Model
-purchaseResource count resource model =
-    let
-        transaction =
-            Resource.purchase count resource
-
-        newResource =
-            Resource.applyTransaction transaction
-
-        newResources =
-            List.map (Resource.replace resource newResource) model.resources
-
-        finalCost =
-            Resource.transactionCost transaction
-    in
-    if model |> canPayFor finalCost then
-        { model
-            | resources = newResources
-            , availableFunds = Currency.subtract finalCost model.availableFunds
-        }
-    else
-        model
-
-
-canPayFor : Currency -> Model -> Bool
-canPayFor cost { availableFunds } =
-    Currency.gte availableFunds cost

--- a/src/elm/Update.elm
+++ b/src/elm/Update.elm
@@ -5,10 +5,8 @@ module Update
         , update
         )
 
-import Data.Currency as Currency
 import Data.Expirable as Expirable
-import Data.IncomeRate as IncomeRate
-import Data.Resource as Resource
+import Data.Inventory as Inventory
 import Model exposing (Model, Msg(..))
 import Time
 
@@ -37,17 +35,17 @@ update msg model =
         NoOp ->
             model ! []
 
-        GenerateCurrency ->
-            { model | availableFunds = Currency.add (Currency.Currency 1) model.availableFunds } ! []
-
         DecrementToastMessages ->
             { model | toastMessages = Expirable.tickAll model.toastMessages } ! []
 
+        GenerateCurrency ->
+            { model | inventory = Inventory.generateCurrency model.inventory } ! []
+
         AccrueValue ->
             { model
-                | availableFunds = IncomeRate.addToCurrency (IncomeRate.multiply (Resource.totalIncomeRate model.resources) (updateFrequencyInMs / 1000)) model.availableFunds
+                | inventory = Inventory.accrueValue (updateFrequencyInMs / 1000) model.inventory
             }
                 ! []
 
         PurchaseResource resource ->
-            Model.purchaseResource 1 resource model ! []
+            { model | inventory = Inventory.purchaseResource 1 resource model.inventory } ! []

--- a/src/elm/View.elm
+++ b/src/elm/View.elm
@@ -3,7 +3,7 @@ module View
         ( view
         )
 
-import Data.Currency as Currency
+import Data.Inventory as Inventory
 import Data.Resource as Resource
 import Html exposing (..)
 import Html.Events exposing (onClick)
@@ -16,13 +16,13 @@ view model =
         [ text "Hello world"
         , button [ onClick GenerateCurrency ] [ text "Make a thing" ]
         , br [] []
-        , text <| toString <| Currency.map (toFloat << truncate) model.availableFunds
+        , text <| toString <| Inventory.availableFunds model.inventory
         , br [] []
         , text <| toString model.toastMessages
         , br [] []
-        , text <| "Rate per second: " ++ toString (Resource.totalIncomeRate model.resources)
+        , text <| "Rate per second: " ++ toString (Resource.totalIncomeRate <| Inventory.resources model.inventory)
         , br [] []
-        , resourcesList model.resources
+        , resourcesList <| Inventory.resources model.inventory
         ]
 
 

--- a/tests/InventoryTest.elm
+++ b/tests/InventoryTest.elm
@@ -1,9 +1,9 @@
-module ModelTest exposing (..)
+module InventoryTest exposing (..)
 
 import Data.Currency as Currency
+import Data.Inventory as Inventory exposing (Inventory)
 import Data.Resource as Resource
 import Expect
-import Model exposing (Model)
 import Test exposing (..)
 
 
@@ -17,22 +17,16 @@ doubleCostResource =
     Resource.build "Double cost resource" 1 2 (Currency.Currency 5)
 
 
-initialModel : Model
+initialModel : Inventory
 initialModel =
-    let
-        initial =
-            Model.initial
-    in
-    { initial | resources = [ constantCostResource, doubleCostResource ] }
+    Inventory.initial
+        |> Inventory.replaceResources [ constantCostResource, doubleCostResource ]
 
 
-initialModelWithAvailableFunds : Currency.Currency -> Model
+initialModelWithAvailableFunds : Currency.Currency -> Inventory
 initialModelWithAvailableFunds funds =
-    let
-        model =
-            initialModel
-    in
-    { model | availableFunds = funds }
+    initialModel
+        |> Inventory.setAvailableFunds funds
 
 
 suite : Test
@@ -42,22 +36,22 @@ suite =
             [ test "disallows purchasing without enough funds" <|
                 \_ ->
                     Expect.equal
-                        (Model.purchaseResource 1 constantCostResource initialModel)
+                        (Inventory.purchaseResource 1 constantCostResource initialModel)
                         initialModel
             , test "allows purchasing with enough funds" <|
                 \_ ->
                     Expect.equal
-                        (Model.purchaseResource 1 constantCostResource (initialModelWithAvailableFunds <| Currency.Currency 5)).availableFunds
+                        (Inventory.availableFunds <| Inventory.purchaseResource 1 constantCostResource (initialModelWithAvailableFunds <| Currency.Currency 5))
                         Currency.zero
             , test "allows purchasing multiple with enough funds" <|
                 \_ ->
                     Expect.equal
-                        (Model.purchaseResource 4 constantCostResource (initialModelWithAvailableFunds <| Currency.Currency 250)).availableFunds
+                        (Inventory.availableFunds <| Inventory.purchaseResource 4 constantCostResource (initialModelWithAvailableFunds <| Currency.Currency 250))
                         (Currency.Currency 230)
             , test "maintains updated costs if the resource has a multiplier" <|
                 \_ ->
                     Expect.equal
-                        (Model.purchaseResource 4 doubleCostResource (initialModelWithAvailableFunds <| Currency.Currency 250)).availableFunds
+                        (Inventory.availableFunds <| Inventory.purchaseResource 4 doubleCostResource (initialModelWithAvailableFunds <| Currency.Currency 250))
                         (Currency.Currency 175)
             ]
         ]


### PR DESCRIPTION
What?
=====

This is the start of shifting resource management and a wallet (which
holds available currency) behind an `Inventory` type.

There are three discrete types of actions to be taken on an inventory:

* accrual of value based on a particular time period
* proactive generation of currency via user input (clicking)
* purchasing of resources

Additional game state/complexity (e.g. purchased static bonuses or
multipliers) would also be captured here in the future.