### PR TITLE
Calculate price based on the number of items purchased

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -8,6 +8,7 @@
     ],
     "exposed-modules": [],
     "dependencies": {
+        "eeue56/elm-all-dict": "2.0.1 <= v < 3.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "elm-lang/http": "1.0.0 <= v < 2.0.0"

--- a/src/elm/Data/Inventory.elm
+++ b/src/elm/Data/Inventory.elm
@@ -5,12 +5,14 @@ module Data.Inventory
         , availableFunds
         , generateCurrency
         , initial
+        , initialWithResources
         , purchaseResource
-        , replaceResources
         , resources
+        , resourcesWithLevels
         , setAvailableFunds
         )
 
+import AllDict exposing (AllDict)
 import Data.Currency as Currency
 import Data.IncomeRate as IncomeRate
 import Data.Resource as Resource
@@ -20,13 +22,12 @@ type Wallet
     = Wallet Currency.Currency
 
 
+type alias Resources =
+    AllDict Resource.Level Resource.Resource String
+
+
 type Inventory
-    = Inventory Wallet (List Resource.Resource)
-
-
-replaceResources : List Resource.Resource -> Inventory -> Inventory
-replaceResources newResources (Inventory wallet _) =
-    Inventory wallet newResources
+    = Inventory Wallet Resources
 
 
 setAvailableFunds : Currency.Currency -> Inventory -> Inventory
@@ -44,6 +45,11 @@ initial =
     Inventory emptyWallet initialResources
 
 
+initialWithResources : List ( Resource.Level, Resource.Resource ) -> Inventory
+initialWithResources =
+    Inventory emptyWallet << AllDict.fromList toString
+
+
 generateCurrency : Inventory -> Inventory
 generateCurrency (Inventory (Wallet funds) resources) =
     let
@@ -57,7 +63,7 @@ accrueValue : Float -> Inventory -> Inventory
 accrueValue frequency (Inventory (Wallet funds) resources) =
     let
         totalIncomeRate =
-            Resource.totalIncomeRate resources
+            Resource.totalIncomeRate <| AllDict.values resources
 
         accruedValueTotal =
             IncomeRate.toCurrency <| IncomeRate.multiply totalIncomeRate frequency
@@ -74,29 +80,39 @@ availableFunds (Inventory (Wallet funds) _) =
 
 
 resources : Inventory -> List Resource.Resource
-resources (Inventory _ list) =
-    list
+resources (Inventory _ resources) =
+    AllDict.values resources
 
 
-purchaseResource : Int -> Resource.Resource -> Inventory -> Inventory
-purchaseResource count resource (Inventory wallet resources) =
-    let
-        transaction =
-            Resource.purchase count resource
+resourcesWithLevels : Inventory -> List ( Resource.Level, Resource.Resource )
+resourcesWithLevels (Inventory _ resources) =
+    AllDict.toList resources
 
-        newResource =
-            Resource.applyTransaction transaction
 
-        newResources =
-            List.map (Resource.replace resource newResource) resources
+purchaseResource : Int -> Resource.Level -> Inventory -> Inventory
+purchaseResource count level (Inventory wallet resources) =
+    case AllDict.get level resources of
+        Nothing ->
+            Inventory wallet resources
 
-        finalCost =
-            Resource.transactionCost transaction
-    in
-    if wallet |> canPayFor finalCost then
-        Inventory (deductFromWallet finalCost wallet) newResources
-    else
-        Inventory wallet resources
+        Just resource ->
+            let
+                transaction =
+                    Resource.purchase count resource
+
+                newResource =
+                    Resource.applyTransaction transaction
+
+                newResources =
+                    AllDict.update level (always <| Just newResource) resources
+
+                finalCost =
+                    Resource.transactionCost transaction
+            in
+            if wallet |> canPayFor finalCost then
+                Inventory (deductFromWallet finalCost wallet) newResources
+            else
+                Inventory wallet resources
 
 
 canPayFor : Currency.Currency -> Wallet -> Bool
@@ -109,13 +125,14 @@ walletValue (Wallet value) =
     value
 
 
-initialResources : List Resource.Resource
+initialResources : Resources
 initialResources =
-    [ Resource.build "Cursor" 0.1 1.07 (Currency.Currency 15)
-    , Resource.build "Backpack" 1 1.07 (Currency.Currency 100)
-    , Resource.build "Skateboard" 8 1.07 (Currency.Currency 1100)
-    , Resource.build "Bicycle" 47 1.07 (Currency.Currency 12000)
-    ]
+    AllDict.fromList toString
+        [ ( Resource.L1, Resource.build "Cursor" 0.1 1.07 (Currency.Currency 15) )
+        , ( Resource.L2, Resource.build "Backpack" 1 1.07 (Currency.Currency 100) )
+        , ( Resource.L3, Resource.build "Skateboard" 8 1.07 (Currency.Currency 1100) )
+        , ( Resource.L4, Resource.build "Bicycle" 47 1.07 (Currency.Currency 12000) )
+        ]
 
 
 deductFromWallet : Currency.Currency -> Wallet -> Wallet

--- a/src/elm/Model.elm
+++ b/src/elm/Model.elm
@@ -19,7 +19,7 @@ type alias Model =
 type Msg
     = NoOp
     | DecrementToastMessages
-    | PurchaseResource Resource.Resource
+    | PurchaseResource Resource.Level
     | AccrueValue
     | GenerateCurrency
 

--- a/src/elm/Update.elm
+++ b/src/elm/Update.elm
@@ -47,5 +47,5 @@ update msg model =
             }
                 ! []
 
-        PurchaseResource resource ->
-            { model | inventory = Inventory.purchaseResource 1 resource model.inventory } ! []
+        PurchaseResource level ->
+            { model | inventory = Inventory.purchaseResource 1 level model.inventory } ! []

--- a/src/elm/View.elm
+++ b/src/elm/View.elm
@@ -22,17 +22,17 @@ view model =
         , br [] []
         , text <| "Rate per second: " ++ toString (Resource.totalIncomeRate <| Inventory.resources model.inventory)
         , br [] []
-        , resourcesList <| Inventory.resources model.inventory
+        , resourcesList <| Inventory.resourcesWithLevels model.inventory
         ]
 
 
-resourcesList : List Resource.Resource -> Html Msg
+resourcesList : List ( Resource.Level, Resource.Resource ) -> Html Msg
 resourcesList resources =
     ul []
         (List.map
-            (\resource ->
+            (\( level, resource ) ->
                 li []
-                    [ button [ onClick <| PurchaseResource resource ] [ text <| "Buy " ++ toString resource.name ++ " for " ++ toString (Resource.currentPrice resource) ]
+                    [ button [ onClick <| PurchaseResource level ] [ text <| "Buy " ++ toString resource.name ++ " for " ++ toString (Resource.currentPrice resource) ]
                     ]
             )
             resources

--- a/tests/Data/ResourceTest.elm
+++ b/tests/Data/ResourceTest.elm
@@ -41,5 +41,25 @@ suite =
                     Expect.equal
                         (Resource.currentPrice <| Resource.applyTransaction <| Resource.purchase 5 doubleCostResource)
                         (Currency.Currency 160)
+            , test "calculates the current price with an existing inventory" <|
+                \_ ->
+                    Expect.equal
+                        (Resource.currentPrice <| Resource.applyTransaction <| Resource.purchase 4 <| Resource.applyTransaction <| Resource.purchase 1 doubleCostResource)
+                        (Currency.Currency 160)
+            , test "calculates the current price with an existing inventory and no new purchase" <|
+                \_ ->
+                    Expect.equal
+                        (Resource.currentPrice <| Resource.applyTransaction <| Resource.purchase 0 <| Resource.applyTransaction <| Resource.purchase 1 doubleCostResource)
+                        (Currency.Currency 10)
+            , test "disallows purchasing negative amounts" <|
+                \_ ->
+                    Expect.equal
+                        (Resource.currentPrice <| Resource.applyTransaction <| Resource.purchase -2 doubleCostResource)
+                        (Currency.Currency 5)
+            , test "does not decrement total purchased count when purchasing negative amounts" <|
+                \_ ->
+                    Expect.equal
+                        (Resource.totalPurchasedCount <| Resource.applyTransaction <| Resource.purchase -2 doubleCostResource)
+                        0
             ]
         ]

--- a/tests/InventoryTest.elm
+++ b/tests/InventoryTest.elm
@@ -19,8 +19,10 @@ doubleCostResource =
 
 initialModel : Inventory
 initialModel =
-    Inventory.initial
-        |> Inventory.replaceResources [ constantCostResource, doubleCostResource ]
+    Inventory.initialWithResources
+        [ ( Resource.L1, constantCostResource )
+        , ( Resource.L2, doubleCostResource )
+        ]
 
 
 initialModelWithAvailableFunds : Currency.Currency -> Inventory
@@ -36,22 +38,31 @@ suite =
             [ test "disallows purchasing without enough funds" <|
                 \_ ->
                     Expect.equal
-                        (Inventory.purchaseResource 1 constantCostResource initialModel)
+                        (Inventory.purchaseResource 1 Resource.L1 initialModel)
                         initialModel
             , test "allows purchasing with enough funds" <|
                 \_ ->
                     Expect.equal
-                        (Inventory.availableFunds <| Inventory.purchaseResource 1 constantCostResource (initialModelWithAvailableFunds <| Currency.Currency 5))
+                        (Inventory.availableFunds <| Inventory.purchaseResource 1 Resource.L1 (initialModelWithAvailableFunds <| Currency.Currency 5))
                         Currency.zero
             , test "allows purchasing multiple with enough funds" <|
                 \_ ->
                     Expect.equal
-                        (Inventory.availableFunds <| Inventory.purchaseResource 4 constantCostResource (initialModelWithAvailableFunds <| Currency.Currency 250))
+                        (Inventory.availableFunds <| Inventory.purchaseResource 4 Resource.L1 (initialModelWithAvailableFunds <| Currency.Currency 250))
                         (Currency.Currency 230)
             , test "maintains updated costs if the resource has a multiplier" <|
                 \_ ->
                     Expect.equal
-                        (Inventory.availableFunds <| Inventory.purchaseResource 4 doubleCostResource (initialModelWithAvailableFunds <| Currency.Currency 250))
+                        (Inventory.availableFunds <| Inventory.purchaseResource 4 Resource.L2 (initialModelWithAvailableFunds <| Currency.Currency 250))
+                        (Currency.Currency 175)
+            , test "supports chaining multiple purchases" <|
+                \_ ->
+                    Expect.equal
+                        ((initialModelWithAvailableFunds <| Currency.Currency 250)
+                            |> Inventory.purchaseResource 2 Resource.L2
+                            |> Inventory.purchaseResource 2 Resource.L2
+                            |> Inventory.availableFunds
+                        )
                         (Currency.Currency 175)
             ]
         ]

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -9,6 +9,7 @@
     ],
     "exposed-modules": [],
     "dependencies": {
+        "eeue56/elm-all-dict": "2.0.1 <= v < 3.0.0",
         "eeue56/elm-html-test": "5.2.0 <= v < 6.0.0",
         "elm-community/elm-test": "4.0.0 <= v < 5.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",


### PR DESCRIPTION
What?
=====

This converts the inventory's resources from a list of resources to an
`AllDict.AllDict` with a `Resource.Level` as the key. The notion of having a
level as a key guarantees some amount of uniqueness across the various
resources and allows for simplification of the inventory due to the `Level`
being the identifier instead of the `Resource` (which changes over time due to
it currently tracking the total number purchased).