### PR TITLE
Add decrease cost multiplier types

### DIFF
--- a/src/elm/Data/Increasable.elm
+++ b/src/elm/Data/Increasable.elm
@@ -13,6 +13,7 @@ module Data.Increasable
         , incrementTotalPurchased
         , initialTotalCount
         , multiplierValue
+        , noOp
         , purchase
         , totalPurchasedCount
         )
@@ -47,6 +48,11 @@ type alias Increasable a =
 buildMultiplier : Float -> Multiplier
 buildMultiplier =
     Multiplier
+
+
+noOp : Multiplier
+noOp =
+    buildMultiplier 1
 
 
 multiplierValue : Multiplier -> Float

--- a/src/elm/Data/Multipliers/Limited.elm
+++ b/src/elm/Data/Multipliers/Limited.elm
@@ -23,6 +23,8 @@ initial =
 type MultiplierType
     = IncreaseGlobalProduction
     | IncreaseLevelProduction Resource.Level
+    | DecreaseGlobalCost
+    | DecreaseLevelCost Resource.Level
 
 
 clickMultipliers : Model -> Increasable.Multiplier
@@ -57,4 +59,13 @@ toResourceLevelMultiplier level multiplierType =
             if l == level then
                 Increasable.buildMultiplier 7
             else
-                Increasable.buildMultiplier 1
+                Increasable.noOp
+
+        DecreaseGlobalCost ->
+            Increasable.buildMultiplier 0.9
+
+        DecreaseLevelCost l ->
+            if l == level then
+                Increasable.buildMultiplier 0.77
+            else
+                Increasable.noOp


### PR DESCRIPTION
Why: 

We want to be able to apply discounts to cost of resources from ether random events or user actions.

How:

This adds a discounts field to the inventory model which is a list of limited multipliers.  Durning the purchase function a new function ```applyDiscounts``` which will combine all the limited multiplier discounts and update the final cost of the transaction.  Also, DecreaseGlobalCost and DecreaseLevelCost where added to the Multiplier type to express multipliers that discount a resource cost.  

~~~While trying to implement a calculation for the decrease in cost to a resource, it wasn't clear to me the best way to go about it.  Currently the cost multiplier for a resource is defined when it is built and there is not a clear way (at least to me) to modify it.  We could either add a new attribute to resources for temporary multipliers that could be updated by the clicking the random events, or have top level multipliers in the inventory that can be checked for when calculating the cost of a resource, or something else i haven't thought about.  I wanted to get consensus on the best way to move forward before getting too far into it.~~~