### PR TITLE
Apply limited multipliers

### DIFF
--- a/src/elm/Data/GameConfiguration.elm
+++ b/src/elm/Data/GameConfiguration.elm
@@ -16,6 +16,7 @@ module Data.GameConfiguration
         , levelName
         , levelResourceMultiplierCost
         , limitedDecreasableMultiplier
+        , limitedEventDuration
         , limitedIncreasableMultiplier
         , randomEventConfig
         , resourceMultiplierConfig
@@ -245,6 +246,11 @@ limitedIncreasableMultiplier =
 limitedDecreasableMultiplier : LimitedMultiplier
 limitedDecreasableMultiplier =
     Increasable.buildMultiplier 0.8
+
+
+limitedEventDuration : Float
+limitedEventDuration =
+    75
 
 
 resourceMultiplierConfig : ResourceMultiplier

--- a/src/elm/Data/GameConfiguration.elm
+++ b/src/elm/Data/GameConfiguration.elm
@@ -257,5 +257,5 @@ resourceMultiplierConfig =
 randomEventConfig : RandomEvent
 randomEventConfig =
     { frequency = 15 * Time.second
-    , eventVisibilityDuration = 10 * Time.second
+    , eventVisibilityDuration = 10
     }

--- a/src/elm/Data/Inventory.elm
+++ b/src/elm/Data/Inventory.elm
@@ -2,6 +2,7 @@ module Data.Inventory
     exposing
         ( Inventory
         , accrueValue
+        , addLimitedMultiplier
         , availableFunds
         , canSpend
         , clickAmount
@@ -208,6 +209,11 @@ applyPurchaseDiscounts level discounts preDiscountCost =
         |> LimitedMultipliers.resourceLevelMultipliers discounts
         |> Increasable.multiplierValue
         |> Currency.multiply preDiscountCost
+
+
+addLimitedMultiplier : LimitedMultipliers.MultiplierType -> Inventory -> Inventory
+addLimitedMultiplier multiplierType (Inventory ({ multipliers } as inventory)) =
+    Inventory { inventory | multipliers = Multipliers.addLimitedMultiplier multiplierType multipliers }
 
 
 canSpend : Currency.Currency -> Inventory -> Bool

--- a/src/elm/Data/Multipliers.elm
+++ b/src/elm/Data/Multipliers.elm
@@ -1,6 +1,7 @@
 module Data.Multipliers
     exposing
         ( Model
+        , addLimitedMultiplier
         , clickAmount
         , clickMultiplierCost
         , increaseMultiplierForLevel
@@ -65,6 +66,11 @@ increaseMultiplierForLevel (Multipliers _ resourcesMultipliers limitedMultiplier
         [ ResourceMultiplier.resourceLevelMultipliers resourcesMultipliers level
         , LimitedMultiplier.resourceLevelMultipliers limitedMultipliers level
         ]
+
+
+addLimitedMultiplier : LimitedMultiplier.MultiplierType -> Model -> Model
+addLimitedMultiplier multiplierType model =
+    mapLimited (\xs -> LimitedMultiplier.build multiplierType :: xs) model
 
 
 clickAmount : Model -> Currency.Currency

--- a/src/elm/Data/Multipliers/Limited.elm
+++ b/src/elm/Data/Multipliers/Limited.elm
@@ -1,6 +1,8 @@
 module Data.Multipliers.Limited
     exposing
         ( Model
+        , MultiplierType(..)
+        , build
         , clickMultipliers
         , initial
         , resourceLevelMultipliers
@@ -25,6 +27,11 @@ type MultiplierType
     | IncreaseLevelProduction Config.Level
     | DecreaseGlobalCost
     | DecreaseLevelCost Config.Level
+
+
+build : MultiplierType -> Expirable.Expirable MultiplierType
+build =
+    Expirable.expiresIn (Expirable.SecondsRemaining Config.limitedEventDuration)
 
 
 clickMultipliers : Model -> Increasable.Multiplier

--- a/src/elm/Model.elm
+++ b/src/elm/Model.elm
@@ -30,6 +30,7 @@ type Msg
     | RollForEvents
     | NewEvent (Maybe Event)
     | TickEvents
+    | AddEvent Event
 
 
 initial : Model

--- a/src/elm/Update.elm
+++ b/src/elm/Update.elm
@@ -74,6 +74,13 @@ update msg model =
             }
                 ! []
 
+        AddEvent event ->
+            { model
+                | inventory = Inventory.addLimitedMultiplier (Event.toMultiplierType event) model.inventory
+                , events = []
+            }
+                ! []
+
         TickEvents ->
             { model | events = Expirable.tickAll model.events } ! []
 

--- a/src/static/styles/main.scss
+++ b/src/static/styles/main.scss
@@ -12,6 +12,41 @@ body {
   color: $dark-brown;
 }
 
+.events-container {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+
+  .event {
+    $size: 60px;
+    z-index: 1;
+    margin-left: -1.25*$size;
+    margin-top: -1.25*$size;
+    position: absolute;
+
+    .multiplier-icon {
+      $gray: darken(grey, 35%);
+      border-radius: 50%;
+      border: $size/4 solid $gray;
+      color: $gray;
+      cursor: pointer;
+      font-size: $size;
+      height: $size;
+      mask-image: url(knockout.png);
+      opacity: 0.7;
+      padding: $size/2;
+      transition: all 0.1s ease-in;
+      width: $size;
+
+      &:hover {
+        transform: rotate(10deg);
+      }
+    }
+  }
+}
+
 .container {
   display: grid;
   grid-template-columns: auto 30vw;


### PR DESCRIPTION
What?
=====

This introduces the ability to click on level-specific and global multipliers
based on the randomly-generated `events` list on the top-level `Model`.

It does so by updating the markup and CSS to overlay the events container atop
the grid-based container, and when generating events randomly, builds up an
offset used to relatively position the elements to interact with. These
elements are placed in the inner 80% of the window (both width and height) by
limiting the range of integers built and selected randomly to be 10 <= n <= 90.

It also configures the event duration of the multiplier (which starts at a
blanket 75 seconds).