### PR TITLE
Introduce stackable increased random drops (and extended duration)

### DIFF
--- a/src/elm/Data/Event.elm
+++ b/src/elm/Data/Event.elm
@@ -16,6 +16,7 @@ import Random.Extra as Random
 type Event
     = GlobalRateIncrease Offset
     | LocalRateIncrease Offset Config.Level
+    | ImprovedRandomEvents Offset
 
 
 type Offset
@@ -31,10 +32,14 @@ toMultiplierType event =
         LocalRateIncrease _ level ->
             Multipliers.IncreaseLevelProduction level
 
+        ImprovedRandomEvents _ ->
+            Multipliers.ImproveRandomEvents
+
 
 all : Offset -> List Config.Level -> List Event
 all offset levels =
     GlobalRateIncrease offset
+        :: ImprovedRandomEvents offset
         :: List.map (LocalRateIncrease offset) levels
 
 

--- a/src/elm/Data/Inventory.elm
+++ b/src/elm/Data/Inventory.elm
@@ -15,6 +15,7 @@ module Data.Inventory
         , purchaseResource
         , purchaseResourceMultiplier
         , purchasedLevels
+        , randomEventConfig
         , resourceMultiplierCost
         , resources
         , resourcesWithLevels
@@ -44,6 +45,21 @@ type Inventory
         , discounts : LimitedMultipliers.Model
         , resources : Resources
         }
+
+
+randomEventConfig : Inventory -> Config.RandomEvent
+randomEventConfig (Inventory { multipliers }) =
+    let
+        multiplier =
+            Increasable.multiplierValue <| Multipliers.randomEventsMultiplier multipliers
+
+        randomConfig =
+            Config.randomEventConfig
+    in
+    { randomConfig
+        | frequency = randomConfig.frequency * multiplier
+        , eventVisibilityDuration = randomConfig.eventVisibilityDuration / multiplier
+    }
 
 
 clickAmount : Inventory -> Currency.Currency

--- a/src/elm/Data/Multipliers.elm
+++ b/src/elm/Data/Multipliers.elm
@@ -8,6 +8,7 @@ module Data.Multipliers
         , incrementClickMultiplier
         , incrementResourceMultiplier
         , initial
+        , randomEventsMultiplier
         , resourceMultiplierCost
         , tick
         )
@@ -71,6 +72,11 @@ increaseMultiplierForLevel (Multipliers _ resourcesMultipliers limitedMultiplier
 addLimitedMultiplier : LimitedMultiplier.MultiplierType -> Model -> Model
 addLimitedMultiplier multiplierType model =
     mapLimited (\xs -> LimitedMultiplier.build multiplierType :: xs) model
+
+
+randomEventsMultiplier : Model -> Increasable.Multiplier
+randomEventsMultiplier (Multipliers _ _ limitedMultipliers) =
+    LimitedMultiplier.randomEventsMultiplier limitedMultipliers
 
 
 clickAmount : Model -> Currency.Currency

--- a/src/elm/Data/Multipliers/Limited.elm
+++ b/src/elm/Data/Multipliers/Limited.elm
@@ -5,6 +5,7 @@ module Data.Multipliers.Limited
         , build
         , clickMultipliers
         , initial
+        , randomEventsMultiplier
         , resourceLevelMultipliers
         )
 
@@ -27,6 +28,7 @@ type MultiplierType
     | IncreaseLevelProduction Config.Level
     | DecreaseGlobalCost
     | DecreaseLevelCost Config.Level
+    | ImproveRandomEvents
 
 
 build : MultiplierType -> Expirable.Expirable MultiplierType
@@ -44,6 +46,17 @@ resourceLevelMultipliers : Model -> Config.Level -> Increasable.Multiplier
 resourceLevelMultipliers model level =
     List.map (toResourceLevelMultiplier level << Expirable.value) model
         |> Increasable.combineMultipliers
+
+
+randomEventsMultiplier : Model -> Increasable.Multiplier
+randomEventsMultiplier model =
+    let
+        exp =
+            List.filter ((==) ImproveRandomEvents << Expirable.value) model
+                |> List.length
+                |> toFloat
+    in
+    Increasable.buildMultiplier <| 2 ^ negate exp
 
 
 toClickMultiplier : MultiplierType -> Increasable.Multiplier
@@ -76,3 +89,6 @@ toResourceLevelMultiplier level multiplierType =
                 Config.limitedDecreasableMultiplier
             else
                 Increasable.noOp
+
+        ImproveRandomEvents ->
+            Increasable.noOp

--- a/src/elm/View.elm
+++ b/src/elm/View.elm
@@ -149,6 +149,15 @@ viewEvent expirable =
                 ]
                 [ levelToIcon level ]
 
+        ImprovedRandomEvents offset ->
+            a
+                [ class "event"
+                , offsetToStyle offset
+                , title "Improve random events"
+                , onClick <| AddEvent event
+                ]
+                [ randomEventIcon ]
+
 
 offsetToStyle : Offset -> Html.Attribute a
 offsetToStyle (Offset xpos ypos) =
@@ -173,3 +182,8 @@ resourceItem inventory level resource_ =
 suitcaseIcon : Html a
 suitcaseIcon =
     FA.iconWithOptions FA.suitcase FA.Solid [ FA.Size <| FA.Mult 2 ] [ class "multiplier-icon" ]
+
+
+randomEventIcon : Html a
+randomEventIcon =
+    FA.iconWithOptions FA.tachometerAlt FA.Solid [ FA.Size <| FA.Mult 2 ] [ class "multiplier-icon" ]


### PR DESCRIPTION
What?
=====

This introduces random event config to be calculated through inventory; this
allows for multipliers to influence random drops. Random drop improvements can
stack, meaning two random drop improvements will quarter the time between
possibilities of dropping.