### PR TITLE
Only display level-specific events for levels already purchased

### DIFF
--- a/src/elm/Data/Event.elm
+++ b/src/elm/Data/Event.elm
@@ -32,10 +32,10 @@ toMultiplierType event =
             Multipliers.IncreaseLevelProduction level
 
 
-all : Offset -> List Event
-all offset =
+all : Offset -> List Config.Level -> List Event
+all offset levels =
     GlobalRateIncrease offset
-        :: List.map (LocalRateIncrease offset) Config.allLevels
+        :: List.map (LocalRateIncrease offset) levels
 
 
 totalOdds : Int
@@ -43,18 +43,18 @@ totalOdds =
     2
 
 
-optionalRandom : Generator (Maybe Event)
-optionalRandom =
-    random
+optionalRandom : List Config.Level -> Generator (Maybe Event)
+optionalRandom availableLevels =
+    random availableLevels
         |> Random.maybe (Random.oneIn totalOdds)
 
 
-random : Generator Event
-random =
+random : List Config.Level -> Generator Event
+random availableLevels =
     randomOffset
         |> Random.andThen
             (\offset ->
-                all offset
+                all offset availableLevels
                     |> Random.sample
                     |> Random.map (Maybe.withDefault <| GlobalRateIncrease offset)
             )

--- a/src/elm/Data/Event.elm
+++ b/src/elm/Data/Event.elm
@@ -40,7 +40,7 @@ all offset levels =
 
 totalOdds : Int
 totalOdds =
-    2
+    4
 
 
 optionalRandom : List Config.Level -> Generator (Maybe Event)

--- a/src/elm/Data/GameConfiguration.elm
+++ b/src/elm/Data/GameConfiguration.elm
@@ -9,8 +9,10 @@ module Data.GameConfiguration
         , allLevels
         , buildLevelDict
         , clickMultiplierConfig
+        , filterLevelDict
         , increasableMultiplier
         , levelBaseCost
+        , levelDictKeys
         , levelIcon
         , levelIncomeRate
         , levelName
@@ -44,6 +46,16 @@ type Level
 
 type alias LevelDict a =
     AllDict.AllDict Level a String
+
+
+filterLevelDict : (Level -> a -> Bool) -> LevelDict a -> LevelDict a
+filterLevelDict =
+    AllDict.filter
+
+
+levelDictKeys : LevelDict a -> List Level
+levelDictKeys =
+    AllDict.keys
 
 
 updateFrequencyInMs : Time.Time

--- a/src/elm/Data/Inventory.elm
+++ b/src/elm/Data/Inventory.elm
@@ -14,6 +14,7 @@ module Data.Inventory
         , purchaseClickMultiplier
         , purchaseResource
         , purchaseResourceMultiplier
+        , purchasedLevels
         , resourceMultiplierCost
         , resources
         , resourcesWithLevels
@@ -236,3 +237,13 @@ initialResources =
                 (Config.increasableMultiplier level)
                 (Config.levelBaseCost level)
         )
+
+
+purchasedLevels : Inventory -> List Config.Level
+purchasedLevels (Inventory { resources }) =
+    Config.filterLevelDict
+        (\_ r ->
+            Increasable.totalPurchasedCount r > 0
+        )
+        resources
+        |> Config.levelDictKeys

--- a/src/elm/Update.elm
+++ b/src/elm/Update.elm
@@ -62,7 +62,7 @@ update msg model =
             { model | inventory = Inventory.purchaseClickMultiplier model.inventory } ! []
 
         RollForEvents ->
-            model ! [ Random.generate NewEvent Event.optionalRandom ]
+            model ! [ Random.generate NewEvent (Event.optionalRandom <| Inventory.purchasedLevels model.inventory) ]
 
         NewEvent Nothing ->
             model ! []


### PR DESCRIPTION
What?
=====

Random drops could previously occur for levels that hadn't been
purchased yet; this greatly reduces likelihood that the random drop
would actually be impactful.

This passes purchased levels to the random generator to influence drops,
ensuring only levels purchased can get bonused.