### PR TITLE
Improve game balance for multipliers

### DIFF
--- a/src/elm/Data/GameConfiguration.elm
+++ b/src/elm/Data/GameConfiguration.elm
@@ -232,7 +232,7 @@ levelIcon level =
 
 clickMultiplierConfig : ClickMultiplier
 clickMultiplierConfig =
-    { increaseRate = 2
+    { increaseRate = 2.4
     , baseCost = Currency.Currency 50
     , increasableMultiplier = Increasable.buildMultiplier 3
     }

--- a/src/elm/Data/Increasable.elm
+++ b/src/elm/Data/Increasable.elm
@@ -12,6 +12,7 @@ module Data.Increasable
         , increaseTotalPurchased
         , incrementTotalPurchased
         , initialTotalCount
+        , mapMultiplier
         , multiplierValue
         , noOp
         , purchase
@@ -58,6 +59,11 @@ noOp =
 multiplierValue : Multiplier -> Float
 multiplierValue (Multiplier v) =
     v
+
+
+mapMultiplier : (Float -> Float) -> Multiplier -> Multiplier
+mapMultiplier f (Multiplier v) =
+    Multiplier <| f v
 
 
 combineMultipliers : List Multiplier -> Multiplier

--- a/src/elm/Data/Multipliers/Limited.elm
+++ b/src/elm/Data/Multipliers/Limited.elm
@@ -64,7 +64,7 @@ toResourceLevelMultiplier level multiplierType =
 
         IncreaseLevelProduction l ->
             if l == level then
-                Config.limitedIncreasableMultiplier
+                Increasable.mapMultiplier ((*) 2) Config.limitedIncreasableMultiplier
             else
                 Increasable.noOp
 

--- a/tests/Data/MultipliersTest.elm
+++ b/tests/Data/MultipliersTest.elm
@@ -20,12 +20,12 @@ suite =
                 \_ ->
                     Expect.equal
                         (Multipliers.clickAmount <| Multipliers.incrementClickMultiplier Multipliers.initial)
-                        (Currency.Currency 2)
+                        (Currency.Currency 2.4)
             , test "returns the correct value when incremented multiple times" <|
                 \_ ->
                     Expect.equal
                         (Multipliers.clickAmount <| Multipliers.incrementClickMultiplier <| Multipliers.incrementClickMultiplier <| Multipliers.incrementClickMultiplier Multipliers.initial)
-                        (Currency.Currency 8)
+                        (Currency.Currency 13.824)
             ]
         , describe "clickMultiplierCost"
             [ test "defaults to 50" <|


### PR DESCRIPTION
What?
=====

This updates game balance by improving the persistent click multipliers
to scale better with the game.

This also increases the single-level resource multipliers so they help
a bit more than the global increase.