### PR TITLE
Display time remaining indicators for each of the current limited multipliers

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -15,6 +15,7 @@
         "elm-community/random-extra": "2.0.0 <= v < 3.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
+        "elm-lang/svg": "2.0.0 <= v < 3.0.0",
         "ggb/numeral-elm": "1.4.1 <= v < 2.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"

--- a/src/elm/Data/Inventory.elm
+++ b/src/elm/Data/Inventory.elm
@@ -9,6 +9,7 @@ module Data.Inventory
         , clickAmount
         , clickMultiplierCost
         , currentIncomeRate
+        , currentLimitedMultipliers
         , extractCurrency
         , extractMultipliers
         , extractResources
@@ -32,6 +33,7 @@ module Data.Inventory
 
 import AllDict
 import Data.Currency as Currency
+import Data.Expirable as Expirable
 import Data.GameConfiguration as Config
 import Data.IncomeRate as IncomeRate
 import Data.Increasable as Increasable
@@ -70,6 +72,11 @@ buildFromInitial funds resourcesList multiplierCounts =
         |> setResourcesFromList resourcesList
         |> setWalletFromFloat funds
         |> setMultipliersFromCounts multiplierCounts
+
+
+currentLimitedMultipliers : Inventory -> List (Expirable.Expirable LimitedMultipliers.MultiplierType)
+currentLimitedMultipliers (Inventory { multipliers }) =
+    Multipliers.limited multipliers
 
 
 randomEventConfig : Inventory -> Config.RandomEvent

--- a/src/elm/Data/Multipliers.elm
+++ b/src/elm/Data/Multipliers.elm
@@ -11,6 +11,7 @@ module Data.Multipliers
         , incrementClickMultiplier
         , incrementResourceMultiplier
         , initial
+        , limited
         , randomEventsMultiplier
         , resourceMultiplierCost
         , tick
@@ -120,3 +121,8 @@ extractClick (Multipliers clickMultiplier _ _) =
 extractResources : Model -> ResourceMultiplier.Model
 extractResources (Multipliers _ resourcesMultipliers _) =
     resourcesMultipliers
+
+
+limited : Model -> LimitedMultiplier.Model
+limited (Multipliers _ _ limitedMultipliers) =
+    limitedMultipliers

--- a/src/static/styles/main.scss
+++ b/src/static/styles/main.scss
@@ -5,6 +5,7 @@ $stencil: 'Stardos Stencil', cursive;
 $receipt: 'Inconsolata', monospace;
 $brown: #bb8355;
 $dark-brown: darken($brown, 35%);
+$dark-red: darken(red, 20%);
 
 body {
   background: $brown url(cardboard.jpg) repeat;
@@ -64,7 +65,6 @@ body {
 }
 
 .primary-button {
-  $dark-red: darken(red, 20%);
   font-family: $stencil;
   font-weight: bold;
   color: $dark-red;
@@ -180,7 +180,7 @@ body {
     opacity: 0.6;
   }
 
-  ul {
+  ul.purchasable-resources {
     margin: 0;
     padding: 0 0 1em;
     list-style-type: none;
@@ -239,6 +239,56 @@ body {
         font-size: 3em;
         margin: 0;
       }
+    }
+  }
+}
+
+.active-limited-multipliers {
+  text-align: center;
+  padding: 0;
+  li {
+    display: inline-block;
+  }
+}
+
+.icon-with-remaining-time {
+  position: relative;
+  width: 100px;
+  height: 100px;
+  display: inline-block;
+
+  .multiplier-icon {
+    position: absolute;
+    top: 35px;
+    left: 36px;
+
+    &.fa-bicycle {
+      left: 33px;
+    }
+    &.fa-tachometer-alt {
+      left: 34px;
+      top: 33px;
+    }
+  }
+
+  svg.countdown {
+    transform: rotate(-90deg);
+    height: 100px;
+    width: 100px;
+    circle {
+      transition: stroke-dasharray 1s linear;
+      opacity: 0.5;
+      stroke-width: 8;
+      fill: transparent;
+    }
+
+    circle.used {
+      stroke: #d2d3d4;
+    }
+
+    circle.remaining {
+      stroke: $dark-red;
+      stroke-dashoffset: 0;
     }
   }
 }


### PR DESCRIPTION
What?
=====

This displays the current limited multipliers, as well as pie charts
displaying the amount of remaining time, so players can understand how
much longer a multiplier will be active.