### PR TITLE
Continue to accrue value when the browser tab isn't active

### DIFF
--- a/src/elm/Data/Inventory.elm
+++ b/src/elm/Data/Inventory.elm
@@ -41,6 +41,7 @@ import Data.Multipliers as Multipliers
 import Data.Multipliers.Limited as LimitedMultipliers
 import Data.Resource as Resource
 import Data.Wallet as Wallet exposing (Wallet)
+import Time
 
 
 type alias Resources =
@@ -119,9 +120,9 @@ setWalletFromFloat newFunds (Inventory inventory) =
     Inventory { inventory | wallet = Wallet.fromCurrency (Currency.Currency newFunds) }
 
 
-tickMultipliers : Inventory -> Inventory
-tickMultipliers (Inventory ({ multipliers } as inventory)) =
-    Inventory { inventory | multipliers = Multipliers.tick multipliers }
+tickMultipliers : Time.Time -> Inventory -> Inventory
+tickMultipliers time (Inventory ({ multipliers } as inventory)) =
+    Inventory { inventory | multipliers = Multipliers.tick time multipliers }
 
 
 initialWithResources : List ( Config.Level, Resource.Resource ) -> Inventory

--- a/src/elm/Data/Multipliers.elm
+++ b/src/elm/Data/Multipliers.elm
@@ -24,6 +24,7 @@ import Data.Increasable as Increasable
 import Data.Multipliers.Click as ClickMultiplier
 import Data.Multipliers.Limited as LimitedMultiplier
 import Data.Multipliers.Resource as ResourceMultiplier
+import Time
 
 
 type Model
@@ -58,9 +59,9 @@ mapResources f (Multipliers clickMultiplier resourcesMultipliers limitedMultipli
     Multipliers clickMultiplier (f resourcesMultipliers) limitedMultipliers
 
 
-tick : Model -> Model
-tick =
-    mapLimited Expirable.tickAll
+tick : Time.Time -> Model -> Model
+tick time =
+    mapLimited (Expirable.tickAll time)
 
 
 incrementClickMultiplier : Model -> Model

--- a/src/elm/Model.elm
+++ b/src/elm/Model.elm
@@ -30,8 +30,8 @@ type alias Model =
 
 type Msg
     = NoOp
-    | DecrementToastMessages
-    | TickMultipliers
+    | DecrementToastMessages Time.Time
+    | TickMultipliers Time.Time
     | PurchaseResource Config.Level
     | PurchaseResourceMultiplier Config.Level
     | PurchaseClickMultiplier
@@ -39,8 +39,8 @@ type Msg
     | GenerateCurrency
     | RollForEvents
     | NewEvent (Maybe Event)
-    | TickEvents
-    | TickRecentlyGeneratedCurrency
+    | TickEvents Time.Time
+    | TickRecentlyGeneratedCurrency Time.Time
     | AddEvent Event
     | SetItem
     | GetItem

--- a/src/elm/Model.elm
+++ b/src/elm/Model.elm
@@ -15,6 +15,7 @@ import Data.IncomeRate as IncomeRate
 import Data.Inventory as Inventory
 import LocalStorage exposing (LocalStorage)
 import LocalStorage.SharedTypes exposing (Ports, Value)
+import Time
 
 
 type alias Model =
@@ -23,6 +24,7 @@ type alias Model =
     , events : List (Expirable Event)
     , recentlyGeneratedCurrency : List (Expirable Currency.Currency)
     , storage : LocalStorage Msg
+    , lastAccruedTime : Maybe Time.Time
     }
 
 
@@ -33,7 +35,7 @@ type Msg
     | PurchaseResource Config.Level
     | PurchaseResourceMultiplier Config.Level
     | PurchaseClickMultiplier
-    | AccrueValue
+    | AccrueValue Time.Time
     | GenerateCurrency
     | RollForEvents
     | NewEvent (Maybe Event)
@@ -55,6 +57,7 @@ initial ports =
     , events = []
     , recentlyGeneratedCurrency = []
     , storage = LocalStorage.make ports ""
+    , lastAccruedTime = Nothing
     }
 
 

--- a/src/elm/Update.elm
+++ b/src/elm/Update.elm
@@ -35,10 +35,10 @@ subscriptions model =
             Inventory.randomEventConfig model.inventory
     in
     Sub.batch
-        [ Expirable.expirableSubscription (always DecrementToastMessages)
-        , Expirable.expirableSubscription (always TickMultipliers)
-        , Expirable.expirableSubscription (always TickEvents)
-        , Expirable.expirableSubscription (always TickRecentlyGeneratedCurrency)
+        [ Expirable.expirableSubscription DecrementToastMessages
+        , Expirable.expirableSubscription TickMultipliers
+        , Expirable.expirableSubscription TickEvents
+        , Expirable.expirableSubscription TickRecentlyGeneratedCurrency
         , Time.every Config.updateFrequencyInMs AccrueValue
         , Time.every eventConfig.frequency (always RollForEvents)
         , Time.every (Time.second * 5) (always SetItem)
@@ -52,11 +52,11 @@ update msg model =
         NoOp ->
             model ! []
 
-        DecrementToastMessages ->
-            { model | toastMessages = Expirable.tickAll model.toastMessages } ! []
+        DecrementToastMessages time ->
+            { model | toastMessages = Expirable.tickAll time model.toastMessages } ! []
 
-        TickMultipliers ->
-            { model | inventory = Inventory.tickMultipliers model.inventory } ! []
+        TickMultipliers time ->
+            { model | inventory = Inventory.tickMultipliers time model.inventory } ! []
 
         GenerateCurrency ->
             let
@@ -130,11 +130,11 @@ update msg model =
             }
                 ! []
 
-        TickEvents ->
-            { model | events = Expirable.tickAll model.events } ! []
+        TickEvents time ->
+            { model | events = Expirable.tickAll time model.events } ! []
 
-        TickRecentlyGeneratedCurrency ->
-            { model | recentlyGeneratedCurrency = Expirable.tickAll model.recentlyGeneratedCurrency } ! []
+        TickRecentlyGeneratedCurrency time ->
+            { model | recentlyGeneratedCurrency = Expirable.tickAll time model.recentlyGeneratedCurrency } ! []
 
         GetItem ->
             model ! [ loadInventoryFromLocalStorage model ]

--- a/src/static/styles/main.scss
+++ b/src/static/styles/main.scss
@@ -259,15 +259,25 @@ body {
 
   .multiplier-icon {
     position: absolute;
-    top: 35px;
-    left: 36px;
+    $top: 35px;
+    $left: 36px;
+    top: $top;
+    left: $left;
 
     &.fa-bicycle {
-      left: 33px;
+      left: calc($left - 3px);
+    }
+    &.fa-train {
+      left: calc($left + 2px);
+      top: calc($top + 1px);
+    }
+
+    &.fa-ship {
+      left: calc($left - 4px);
     }
     &.fa-tachometer-alt {
-      left: 34px;
-      top: 33px;
+      left: calc($left - 2px);
+      top: calc($top - 2px);
     }
   }
 


### PR DESCRIPTION
What?
=====

Certain browsers may reduce frequency of subscriptions being run when
the tab isn't active; this results in incorrect accrual of value over
time when the browser is in the background.

This introduces tracking of the last accrued time and compares it
against game update frequency; once the updated time passes outside a
10% threshold, the game uses that time distance to calculate accrued
value instead of the expected update frequency.